### PR TITLE
swaps brew command with 'which hub' for compatibility with Ubuntu users

### DIFF
--- a/bin/submit_hw
+++ b/bin/submit_hw
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require 'json'
 
-hub_not_installed = `brew list --versions hub`.empty?
+hub_not_installed = `which hub`.empty?
 
 if hub_not_installed
   puts "Please install the \`hub\` utility."


### PR DESCRIPTION
Hey Jeff,
Line 4 throws an error for Ubuntu user because it attempts to run a brew command in the console. Just replaced that command with `which hub`, as it's cross compatible with OSX and Ubuntu
